### PR TITLE
Use route length instead of graph

### DIFF
--- a/pytsp/k_opt_tsp.py
+++ b/pytsp/k_opt_tsp.py
@@ -78,7 +78,7 @@ def tsp_3_opt(graph, route=None):
     best_found_route = route
     while improved:
         improved = False
-        for (i, j, k) in possible_segments(len(graph)):
+        for (i, j, k) in possible_segments(len(route)):
             # we check all the possible moves and save the result into the dict
             for opt_case in OptCase:
                 moves_cost[opt_case] = get_solution_cost_change(graph, best_found_route, opt_case, i, j, k)


### PR DESCRIPTION
If the graph is bigger than the route provided then there will be a problem with taking the graph length. A typical use case is when a subset of nodes is selected from the graph to construct a path.